### PR TITLE
Incorrect link generated for reference to FHP

### DIFF
--- a/src/update.c
+++ b/src/update.c
@@ -843,6 +843,7 @@ ex:
 }
 
 
+/** \details \anchor FHP */
 svn_error_t *up__apply_textdelta(void *file_baton,
 		const char *base_checksum,
 		apr_pool_t *pool,
@@ -919,7 +920,7 @@ into_stringbufs:
 	}
 	else
 	{
-		/** \anchor FHP File handle pools.
+		/** \details File handle pools.
 		 *
 		 * This is a bit complicated.
 		 *


### PR DESCRIPTION
Due to the fact that the code for the "File handle pools" is located inside the function doxygen does not generate a proper link. By placing the anchor before the function this has been resolved.